### PR TITLE
CU-868ad2bnm add resolver for revealing a message

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,7 +489,7 @@ GEM
       rubocop-rails (~> 2.24)
       rubocop-rspec (~> 3.0)
       rubocop-rspec_rails (~> 2.30)
-    discord_engine (0.10.0)
+    discord_engine (0.11.0)
       discordrb (~> 3.5)
       jbuilder (~> 2.12)
       rails (>= 7.2.2)

--- a/app/integrations/discord/interactions/resolvers/message.rb
+++ b/app/integrations/discord/interactions/resolvers/message.rb
@@ -6,7 +6,7 @@ module Discord
 
         MESSAGE_CREATED_CONTENT = 'Hey @everyone! here is a new **privy** message'.freeze
         REVEAL_BUTTON_LABEL = 'Reveal'.freeze
-        REVEAL_MESSAGE_RESOLVER = 'Discord::Interactions::Resolvers::RevealMessage'.freeze
+        REVEAL_MESSAGE_RESOLVER = 'RevealMessage'.freeze
 
         def execute_action
           ActiveRecord::Base.transaction do
@@ -43,7 +43,7 @@ module Discord
           reveal_button = DiscordEngine::MessageComponents::Button.new(
             label: REVEAL_BUTTON_LABEL,
             style: :success,
-            resolver_name: REVEAL_MESSAGE_RESOLVER,
+            resolver_name: REVEAL_MESSAGE_RESOLVER.underscore,
             data: { message_id: message.id }
           )
 

--- a/app/integrations/discord/interactions/resolvers/reveal_message.rb
+++ b/app/integrations/discord/interactions/resolvers/reveal_message.rb
@@ -9,7 +9,7 @@ module Discord
           @content = message_text
         rescue ActiveRecord::RecordNotFound => _e
           @content = '⚠️ Could not find the message'
-        rescue Messages::ExpirationTypeError => _e
+        rescue Messages::ExpiredError => _e
           @content = '⚠️ This message has expired'
         ensure
           @callback = DiscordEngine::InteractionCallback.update_message

--- a/app/integrations/discord/interactions/resolvers/reveal_message.rb
+++ b/app/integrations/discord/interactions/resolvers/reveal_message.rb
@@ -1,0 +1,34 @@
+module Discord
+  module Interactions
+    module Resolvers
+      class RevealMessage < DiscordEngine::Resolvers::Resolver
+        attr_reader :callback, :content, :components
+
+        def execute_action
+          message_text = read_message_text!
+          @content = message_text
+        rescue ActiveRecord::RecordNotFound => _e
+          @content = '⚠️ Could not find the message'
+        rescue Messages::ExpirationTypeError => _e
+          @content = '⚠️ This message has expired'
+        ensure
+          @callback = DiscordEngine::InteractionCallback.update_message
+          @components = []
+        end
+
+        private
+
+        def read_message_text!
+          message = ::Message.find(message_id)
+
+          reader = Messages::Reader.new(message)
+          reader.read_message.to_plain_text
+        end
+
+        def message_id
+          @message_id ||= context.metadata.dig(:data, 'message_id')
+        end
+      end
+    end
+  end
+end

--- a/app/views/discord_engine/interactions/reveal_message.jbuilder
+++ b/app/views/discord_engine/interactions/reveal_message.jbuilder
@@ -1,0 +1,7 @@
+json.type @resolver.callback.type
+json.data do
+  json.content @resolver.content
+  json.components do
+    json.array! @resolver.components
+  end
+end

--- a/config/initializers/discord_engine.rb
+++ b/config/initializers/discord_engine.rb
@@ -4,7 +4,8 @@ DiscordEngine.application_id = Rails.application.credentials.discord_application
 
 DiscordEngine.resolvers = [
   'Discord::Interactions::Resolvers::Connect',
-  'Discord::Interactions::Resolvers::Message'
+  'Discord::Interactions::Resolvers::Message',
+  'Discord::Interactions::Resolvers::RevealMessage'
 ]
 
 DiscordEngine.guild_verification = ->(guild) { ::Interface.discord_guild.find_by(external_id: guild.id).present? }

--- a/spec/fixtures/interactions/reveal_message.json
+++ b/spec/fixtures/interactions/reveal_message.json
@@ -1,0 +1,222 @@
+{
+  "app_permissions": "2248473465835073",
+  "application_id": "1296566140188754081",
+  "authorizing_integration_owners": {
+    "0": "1295846289195663360"
+  },
+  "channel": {
+    "flags": 0,
+    "guild_id": "1295846289195663360",
+    "id": "1295846289195663363",
+    "last_message_id": "1310689094829084692",
+    "name": "anuncios",
+    "nsfw": false,
+    "parent_id": "1295846289195663361",
+    "permissions": "2251799813685247",
+    "position": 2,
+    "rate_limit_per_user": 0,
+    "topic": null,
+    "type": 0
+  },
+  "channel_id": "1295846289195663363",
+  "context": 0,
+  "data": {
+    "component_type": 2,
+    "custom_id": "{\"resolver_name\":\"reveal_message\",\"data\":{\"message_id\":12}}"
+  },
+  "entitlement_sku_ids": [],
+  "entitlements": [],
+  "guild": {
+    "features": [],
+    "id": "1295846289195663360",
+    "locale": "en-US"
+  },
+  "guild_id": "1295846289195663360",
+  "guild_locale": "en-US",
+  "id": "1310689132825280582",
+  "locale": "en-US",
+  "member": {
+    "avatar": null,
+    "banner": null,
+    "communication_disabled_until": null,
+    "deaf": false,
+    "flags": 0,
+    "joined_at": "2024-10-15T20:30:31.014000+00:00",
+    "mute": false,
+    "nick": null,
+    "pending": false,
+    "permissions": "2251799813685247",
+    "premium_since": null,
+    "roles": [],
+    "unusual_dm_activity_until": null,
+    "user": {
+      "avatar": null,
+      "avatar_decoration_data": null,
+      "clan": null,
+      "discriminator": "0",
+      "global_name": "immprada",
+      "id": "746492278951903403",
+      "primary_guild": null,
+      "public_flags": 0,
+      "username": "immprada"
+    }
+  },
+  "message": {
+    "attachments": [],
+    "author": {
+      "avatar": null,
+      "avatar_decoration_data": null,
+      "bot": true,
+      "clan": null,
+      "discriminator": "1385",
+      "global_name": null,
+      "id": "1296566140188754081",
+      "primary_guild": null,
+      "public_flags": 524288,
+      "username": "PRIVY-DEV"
+    },
+    "channel_id": "1295846289195663363",
+    "components": [
+      {
+        "components": [
+          {
+            "custom_id": "{\"resolver_name\":\"reveal_message\",\"data\":{\"message_id\":12}}",
+            "id": 2,
+            "label": "Reveal",
+            "style": 3,
+            "type": 2
+          }
+        ],
+        "id": 1,
+        "type": 1
+      }
+    ],
+    "content": "Hey @everyone! here is a new **privy** message",
+    "edited_timestamp": null,
+    "embeds": [],
+    "flags": 0,
+    "id": "1310689094829084692",
+    "mention_everyone": true,
+    "mention_roles": [],
+    "mentions": [],
+    "pinned": false,
+    "timestamp": "2024-11-25T19:30:31.633000+00:00",
+    "tts": false,
+    "type": 0
+  },
+  "token": "aW50ZXJhY3Rpb246MTMxMDY4OTEzMjgyNTI4MDU4MjpObDB5MzM4ckxGUUw5ajFDc29INUwycXM4VkdOSUgxdHNhUmZZdndNSWhWT2ZRUDBMRmcyQjlmd1lYZ3RmcFgwbFk3eEdhRTZCU3NvNHJRTEFZRHpkOW4yc2hFNFBoTFZwTlV2MFo1WGJtVnBFZzlldGZXSVJ2QlZmTTlSSFYyNg",
+  "type": 3,
+  "version": 1,
+  "controller": "discord_engine/interactions",
+  "action": "create",
+  "interaction": {
+    "app_permissions": "2248473465835073",
+    "application_id": "1296566140188754081",
+    "authorizing_integration_owners": {
+      "0": "1295846289195663360"
+    },
+    "channel": {
+      "flags": 0,
+      "guild_id": "1295846289195663360",
+      "id": "1295846289195663363",
+      "last_message_id": "1310689094829084692",
+      "name": "anuncios",
+      "nsfw": false,
+      "parent_id": "1295846289195663361",
+      "permissions": "2251799813685247",
+      "position": 2,
+      "rate_limit_per_user": 0,
+      "topic": null,
+      "type": 0
+    },
+    "channel_id": "1295846289195663363",
+    "context": 0,
+    "data": {
+      "component_type": 2,
+      "custom_id": "{\"resolver_name\":\"reveal_message\",\"data\":{\"message_id\":12}}"
+    },
+    "entitlement_sku_ids": [],
+    "entitlements": [],
+    "guild": {
+      "features": [],
+      "id": "1295846289195663360",
+      "locale": "en-US"
+    },
+    "guild_id": "1295846289195663360",
+    "guild_locale": "en-US",
+    "id": "1310689132825280582",
+    "locale": "en-US",
+    "member": {
+      "avatar": null,
+      "banner": null,
+      "communication_disabled_until": null,
+      "deaf": false,
+      "flags": 0,
+      "joined_at": "2024-10-15T20:30:31.014000+00:00",
+      "mute": false,
+      "nick": null,
+      "pending": false,
+      "permissions": "2251799813685247",
+      "premium_since": null,
+      "roles": [],
+      "unusual_dm_activity_until": null,
+      "user": {
+        "avatar": null,
+        "avatar_decoration_data": null,
+        "clan": null,
+        "discriminator": "0",
+        "global_name": "immprada",
+        "id": "746492278951903403",
+        "primary_guild": null,
+        "public_flags": 0,
+        "username": "immprada"
+      }
+    },
+    "message": {
+      "attachments": [],
+      "author": {
+        "avatar": null,
+        "avatar_decoration_data": null,
+        "bot": true,
+        "clan": null,
+        "discriminator": "1385",
+        "global_name": null,
+        "id": "1296566140188754081",
+        "primary_guild": null,
+        "public_flags": 524288,
+        "username": "PRIVY-DEV"
+      },
+      "channel_id": "1295846289195663363",
+      "components": [
+        {
+          "components": [
+            {
+              "custom_id": "{\"resolver_name\":\"reveal_message\",\"data\":{\"message_id\":12}}",
+              "id": 2,
+              "label": "Reveal",
+              "style": 3,
+              "type": 2
+            }
+          ],
+          "id": 1,
+          "type": 1
+        }
+      ],
+      "content": "Hey @everyone! here is a new **privy** message",
+      "edited_timestamp": null,
+      "embeds": [],
+      "flags": 0,
+      "id": "1310689094829084692",
+      "mention_everyone": true,
+      "mention_roles": [],
+      "mentions": [],
+      "pinned": false,
+      "timestamp": "2024-11-25T19:30:31.633000+00:00",
+      "tts": false,
+      "type": 0
+    },
+    "token": "aW50ZXJhY3Rpb246MTMxMDY4OTEzMjgyNTI4MDU4MjpObDB5MzM4ckxGUUw5ajFDc29INUwycXM4VkdOSUgxdHNhUmZZdndNSWhWT2ZRUDBMRmcyQjlmd1lYZ3RmcFgwbFk3eEdhRTZCU3NvNHJRTEFZRHpkOW4yc2hFNFBoTFZwTlV2MFo1WGJtVnBFZzlldGZXSVJ2QlZmTTlSSFYyNg",
+    "type": 3,
+    "version": 1
+  }
+}

--- a/spec/integrations/discord/interactions/resolvers/reveal_message_spec.rb
+++ b/spec/integrations/discord/interactions/resolvers/reveal_message_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Discord::Interactions::Resolvers::RevealMessage do
   describe '#execute_action', :vcr do
     let(:params) do
       read = load_json('interactions/reveal_message.json')
-      # "{\"resolver_name\":\"reveal_message\",\"data\":{\"message_id\":12}}"
       read['data']['custom_id'] = "{\"resolver_name\":\"reveal_message\",\"data\":{\"message_id\":#{message_id}}}"
 
       read

--- a/spec/integrations/discord/interactions/resolvers/reveal_message_spec.rb
+++ b/spec/integrations/discord/interactions/resolvers/reveal_message_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Discord::Interactions::Resolvers::RevealMessage do
+  subject(:message_resolver) { described_class.new(context:) }
+
+  let(:context) { DiscordEngine::Resolvers::Context.new(params:) }
+  let(:interface) { create(:interface, source: :discord_guild, external_id: context.guild.id) }
+
+  before do
+    interface # ensure interface exists
+    allow(DiscordEngine::Message).to receive(:new).and_call_original
+  end
+
+  describe '#execute_action', :vcr do
+    let(:params) do
+      read = load_json('interactions/reveal_message.json')
+      # "{\"resolver_name\":\"reveal_message\",\"data\":{\"message_id\":12}}"
+      read['data']['custom_id'] = "{\"resolver_name\":\"reveal_message\",\"data\":{\"message_id\":#{message_id}}}"
+
+      read
+    end
+
+    context 'when message relevation succeeds' do
+      let(:message) { create(:message) }
+      let(:message_id) { message.id }
+
+      before do
+        message_resolver.execute_action
+      end
+
+      it 'adds a DiscordEngine::InteractionCallback instance to callback attribute' do
+        expect(message_resolver.callback).to be_an_instance_of(DiscordEngine::InteractionCallback)
+      end
+
+      it 'adds a callback of right type' do
+        expect(message_resolver.callback.type)
+          .to be(DiscordEngine::InteractionCallback::UPDATE_MESSAGE_TYPE)
+      end
+
+      it 'sets success content' do
+        expect(message_resolver.content).to eq(message.content.to_plain_text)
+      end
+
+      it 'sets empty components array' do
+        expect(message_resolver.components).to eq([])
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/reveal_message_basics.rb
+++ b/spec/support/shared_examples/reveal_message_basics.rb
@@ -1,0 +1,14 @@
+RSpec.shared_examples 'reval message basics' do
+  it 'adds a DiscordEngine::InteractionCallback instance to callback attribute' do
+    expect(message_resolver.callback).to be_an_instance_of(DiscordEngine::InteractionCallback)
+  end
+
+  it 'adds a callback of right type' do
+    expect(message_resolver.callback.type)
+      .to be(DiscordEngine::InteractionCallback::UPDATE_MESSAGE_TYPE)
+  end
+
+  it 'sets empty components array' do
+    expect(message_resolver.components).to eq([])
+  end
+end


### PR DESCRIPTION
# Description

## Motivation

<!--- Why is this change required? -->
<!--- What problem does it solve? -->

Privy should show the message content when a user clicks on "Reveal" button

## Solution

<!--- Write a clear description of your proposed changes. If possible, include supporting resources such as images or links. -->

We are adding RevealMessage resolver to resolve the "Reveal" button clicking, and update the message at discord with the content of the message

## Deploy TODOs

<!--- Is there anything exceptional that needs to be done to deploy these changes? -->
<!-- Any environment variables that need to be set or modified? List them here with their corresponding value for each environment -->
<!-- Any script that needs to be run? -->

## Checklist

- [x] I added/updated unit tests for these changes
- [x] I tested manually these changes
- [x] I updated the issue tracker and linked my PR to my ticket.

## Steps to reproduce

<!--- Please describe in detail how you tested your changes. -->
<!-- Add screenshots that support your manual tests  -->

run server and ngrok, update the interactions endpoint at Discord dashboard

### happy path

1. create a message with /message command
![image](https://github.com/user-attachments/assets/27c03a0f-9f64-4650-aad6-3bcd1ac0b67e)

2. clicck "reval"
![image](https://github.com/user-attachments/assets/7ab5c38a-30dd-41ac-81a3-1cc643ca547f)

4. it works°
![image](https://github.com/user-attachments/assets/daa4f823-ff72-4ee4-8dc5-a35ed1f86841)

### message does not exists at DB

1. create a message with /message command
![image](https://github.com/user-attachments/assets/27c03a0f-9f64-4650-aad6-3bcd1ac0b67e)

2. delete the message in rails c
<img width="459" alt="image" src="https://github.com/user-attachments/assets/88c0fede-f858-44cf-92d7-cfa88d13a98b">

3. click "reveal"
![image](https://github.com/user-attachments/assets/7ab5c38a-30dd-41ac-81a3-1cc643ca547f)

4. it works!
![image](https://github.com/user-attachments/assets/ed3cee80-9f3c-497d-a419-ece67ee86b01)

### expired message

1. create a visits based message, of 1 visit:
![image](https://github.com/user-attachments/assets/89cd2e44-4fd9-494e-9f6b-ab06e9e9f30e)

2. add a visit to the message at rails c:
```bash
message = Message.last
MessageVisit.create(message:)
```

3. click "reveal"
![image](https://github.com/user-attachments/assets/7ab5c38a-30dd-41ac-81a3-1cc643ca547f)

4. it works!
![image](https://github.com/user-attachments/assets/e5b932ef-f757-499f-a541-1d8f88456dbf)
