### PR TITLE
CU-868a97htf Use UUID to identify a message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,3 +111,5 @@ end
 
 # Database based asynchronous priority queue system
 gem 'delayed_job_active_record'
+
+gem 'uuid7', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -563,6 +563,7 @@ DEPENDENCIES
   timecop
   turbo-rails
   tzinfo-data
+  uuid7 (~> 0.2.0)
   vcr
   web-console
   webmock

--- a/app/api/privy/messages/show.rb
+++ b/app/api/privy/messages/show.rb
@@ -1,13 +1,13 @@
 module Privy
   module Messages
     class Show < Grape::API
-      desc 'Returns a message by id.'
+      desc 'Returns a message by uuid.'
       params do
-        requires :id, type: Integer, desc: 'ID of the message.'
+        requires :uuid, type: String, desc: 'UUID of the message.'
       end
 
-      get ':id', jbuilder: 'messages/show' do
-        message = Message.find(params[:id])
+      get ':uuid', jbuilder: 'messages/show' do
+        message = Message.find_by!(uuid: params[:uuid])
         @content = ::Messages::Reader.new(message).read_message
       rescue ActiveRecord::RecordNotFound => e
         return error!(e.message, :not_found)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -22,6 +22,6 @@ class MessagesController < ApplicationController
   end
 
   def message
-    @message ||= Message.find(params[:id])
+    @message ||= Message.find_by!(uuid: params[:uuid])
   end
 end

--- a/app/integrations/discord/interactions/resolvers/message.rb
+++ b/app/integrations/discord/interactions/resolvers/message.rb
@@ -31,6 +31,7 @@ module Discord
             external_id: context.guild.id
           )
           message_creator.call
+
           message_creator.message
         end
 
@@ -46,7 +47,7 @@ module Discord
           available_notice = StatusNotices::Available.new(message).build
           available_notice.create(
             channel_id: context.channel_id,
-            reference_id: message.id
+            reference_id: message.uuid
           )
         end
       end

--- a/app/integrations/discord/interactions/resolvers/reveal_message.rb
+++ b/app/integrations/discord/interactions/resolvers/reveal_message.rb
@@ -18,13 +18,13 @@ module Discord
         private
 
         def read_message_text!
-          message = ::Message.find(message_id)
+          message = ::Message.find_by!(uuid: message_uuid)
           reader = Messages::Reader.new(message)
           reader.read_message.to_plain_text
         end
 
-        def message_id
-          @message_id ||= context.metadata.dig(:data, 'message_id')
+        def message_uuid
+          @message_uuid ||= context.metadata.dig(:data, 'message_uuid')
         end
       end
     end

--- a/app/integrations/discord/listeners/create_external_message_listener.rb
+++ b/app/integrations/discord/listeners/create_external_message_listener.rb
@@ -2,7 +2,7 @@ module Discord
   module Listeners
     class CreateExternalMessageListener
       def discord_engine_message_created(payload)
-        DiscordMessages::Creator.new(params: payload[:response], message_id: payload[:reference_id]).call
+        DiscordMessages::Creator.new(params: payload[:response], message_uuid: payload[:reference_id]).call
       end
     end
   end

--- a/app/integrations/discord/status_notices/available.rb
+++ b/app/integrations/discord/status_notices/available.rb
@@ -24,7 +24,7 @@ module Discord
           label: REVEAL_BUTTON_LABEL,
           style: :success,
           resolver_name:,
-          data: { message_id: message.id }
+          data: { message_uuid: message.uuid }
         )
 
         action_row = DiscordEngine::MessageComponents::ActionRow.new

--- a/app/integrations/discord/status_notices/unauthorized.rb
+++ b/app/integrations/discord/status_notices/unauthorized.rb
@@ -15,7 +15,7 @@ module Discord
 
       def build
         DiscordEngine::Message.new(
-          content: format(CONTENT, message_url: message_url(message)),
+          content: format(CONTENT, message_url: message_url(uuid: message.uuid)),
           components: []
         )
       end

--- a/app/models/concerns/uuidable.rb
+++ b/app/models/concerns/uuidable.rb
@@ -1,0 +1,19 @@
+module Uuidable
+  extend ActiveSupport::Concern
+
+  included do
+    before_create :generate_uuid
+  end
+
+  private
+
+  def generate_uuid
+    loop do
+      uuid = UUID7.generate
+      next if self.class.exists?(uuid:)
+
+      self.uuid = uuid
+      break
+    end
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,6 @@
 class Message < ApplicationRecord
+  include Uuidable
+
   enum expiration_type: {
     hour: '0',
     hours: '1',

--- a/app/services/discord_messages/creator.rb
+++ b/app/services/discord_messages/creator.rb
@@ -2,13 +2,13 @@ module DiscordMessages
   class Creator
     attr_reader :discord_message
 
-    def initialize(params:, message_id:)
+    def initialize(params:, message_uuid:)
       @params = params
-      @message_id = message_id
+      @message_uuid = message_uuid
     end
 
     def call
-      message = Message.find(message_id)
+      message = Message.find_by!(uuid: message_uuid)
       @discord_message = DiscordMessage.new(
         channel_id: params['channel_id'],
         external_id: params['id'],
@@ -22,6 +22,6 @@ module DiscordMessages
 
     private
 
-    attr_reader :params, :message_id
+    attr_reader :params, :message_uuid
   end
 end

--- a/app/views/api/messages/create.jbuilder
+++ b/app/views/api/messages/create.jbuilder
@@ -1,6 +1,6 @@
 status :created
 
-json.id @message[:id]
+json.uuid @message[:uuid]
 json.expiration do
   json.duration "#{@message.expiration_limit} #{@message.expiration_type}"
   json.from @message.created_at

--- a/app/views/partials/_confirmation.html.erb
+++ b/app/views/partials/_confirmation.html.erb
@@ -26,7 +26,7 @@
       data-clipboard-target="source"
       type="text"
       data-action="click->clipboard#selectContent"
-      value="<%= message_url(@message) %>"
+      value="<%= message_url(uuid: @message.uuid) %>"
       readonly
       class="w-full bg-gray-100 border border-gray-300 rounded-lg p-2 mt-2 mb-4"
     >

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
 
   mount DiscordEngine::Engine => '/discord'
 
-  resources :messages, only: %i[show new create]
+  resources :messages, only: %i[show new create], param: :uuid
 end

--- a/db/migrate/20250107211042_add_uuid_to_messages.rb
+++ b/db/migrate/20250107211042_add_uuid_to_messages.rb
@@ -1,5 +1,5 @@
 class AddUuidToMessages < ActiveRecord::Migration[7.2]
   def change
-    add_column :messages, :uuid, :uuid
+    add_column :messages, :uuid, :string
   end
 end

--- a/db/migrate/20250107211042_add_uuid_to_messages.rb
+++ b/db/migrate/20250107211042_add_uuid_to_messages.rb
@@ -1,0 +1,5 @@
+class AddUuidToMessages < ActiveRecord::Migration[7.2]
+  def change
+    add_column :messages, :uuid, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -102,7 +102,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_07_211042) do
     t.integer "message_visits_count"
     t.bigint "interface_id"
     t.datetime "expired_at"
-    t.uuid "uuid"
+    t.string "uuid"
     t.index ["interface_id"], name: "index_messages_on_interface_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_26_162326) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_07_211042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -102,6 +102,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_26_162326) do
     t.integer "message_visits_count"
     t.bigint "interface_id"
     t.datetime "expired_at"
+    t.uuid "uuid"
     t.index ["interface_id"], name: "index_messages_on_interface_id"
   end
 

--- a/spec/factories/message.rb
+++ b/spec/factories/message.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     expiration_limit { 1 }
     expiration_type { '0' }
     expired { false }
+    uuid { UUID7.generate }
 
     association :interface
 

--- a/spec/factories/message.rb
+++ b/spec/factories/message.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     expiration_limit { 1 }
     expiration_type { '0' }
     expired { false }
-    uuid { UUID7.generate }
 
     association :interface
 

--- a/spec/integrations/discord/interactions/resolvers/reveal_message_spec.rb
+++ b/spec/integrations/discord/interactions/resolvers/reveal_message_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe Discord::Interactions::Resolvers::RevealMessage do
   describe '#execute_action', :vcr do
     let(:params) do
       read = load_json('interactions/reveal_message.json')
-      read['data']['custom_id'] = "{\"resolver_name\":\"reveal_message\",\"data\":{\"message_id\":#{message_id}}}"
+      read['data']['custom_id'] = "{\"resolver_name\":\"reveal_message\",\"data\":{\"message_uuid\":\"#{uuid}\"}}"
 
       read
     end
 
     context 'when message relevation succeeds' do
       let(:message) { create(:message) }
-      let(:message_id) { message.id }
+      let(:uuid) { message.uuid }
       let(:dicord_message_visibility_job) { class_spy(Discord::Jobs::Messages::HideJob) }
 
       before do
@@ -36,7 +36,7 @@ RSpec.describe Discord::Interactions::Resolvers::RevealMessage do
     end
 
     context 'when message does not exist' do
-      let(:message_id) { 0 }
+      let(:uuid) { '0' }
 
       before do
         message_resolver.execute_action
@@ -51,7 +51,7 @@ RSpec.describe Discord::Interactions::Resolvers::RevealMessage do
 
     context 'when message has expired' do
       let(:message) { create(:message, expiration_limit: 1, expiration_type: 'visit') }
-      let(:message_id) { message.id }
+      let(:uuid) { message.uuid }
 
       before do
         create_list(:message_visit, 1, message:)

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Message, type: :model do
   describe 'validations' do
+    subject { build(:message) }
+
     it { is_expected.to validate_numericality_of(:expiration_limit).only_integer.is_greater_than(0) }
     it { is_expected.to validate_presence_of(:expiration_type) }
     it { is_expected.to validate_presence_of(:content) }

--- a/spec/requests/messages/create_spec.rb
+++ b/spec/requests/messages/create_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Messages API', type: :request do
 
       it "returns a message's id" do
         post('/api/messages', params:)
-        expect(JSON.parse(response.body)['id']).to be_present
+        expect(JSON.parse(response.body)['uuid']).to be_present
       end
 
       context 'when there are extra parameter' do
@@ -45,7 +45,7 @@ RSpec.describe 'Messages API', type: :request do
 
         it "returns a message's id" do
           post('/api/messages', params:)
-          expect(JSON.parse(response.body)['id']).to be_present
+          expect(JSON.parse(response.body)['uuid']).to be_present
         end
       end
     end

--- a/spec/requests/messages/show_spec.rb
+++ b/spec/requests/messages/show_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Messages API', type: :request do
-  describe 'GET /api/messages/:id' do
+  describe 'GET /api/messages/:uuid' do
     let(:messages) { create_list(:message, 5, interface:) }
     let!(:interface) { create(:interface, source: :api) }
 
@@ -9,12 +9,12 @@ RSpec.describe 'Messages API', type: :request do
       let(:sample_message) { messages.sample }
 
       it 'returns ok status' do
-        get "/api/messages/#{sample_message.id}"
+        get "/api/messages/#{sample_message.uuid}"
         expect(response).to have_http_status(:ok)
       end
 
       it "returns the message's content" do
-        get "/api/messages/#{sample_message.id}"
+        get "/api/messages/#{sample_message.uuid}"
         expect(JSON.parse(response.body)['message']['content']).not_to be_empty
       end
     end
@@ -41,12 +41,12 @@ RSpec.describe 'Messages API', type: :request do
       end
 
       it 'returns status code 401' do
-        get "/api/messages/#{expired_message.id}"
+        get "/api/messages/#{expired_message.uuid}"
         expect(response).to have_http_status(:unauthorized)
       end
 
       it 'returns an error message' do
-        get "/api/messages/#{expired_message.id}"
+        get "/api/messages/#{expired_message.uuid}"
         expect(JSON.parse(response.body)['error']).not_to be_empty
       end
     end

--- a/spec/services/discord_messages/creator_spec.rb
+++ b/spec/services/discord_messages/creator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DiscordMessages::Creator do
-  subject(:creator) { described_class.new(params:, message_id:) }
+  subject(:creator) { described_class.new(params:, message_uuid:) }
 
   describe '#call' do
     let(:params) do
@@ -9,7 +9,7 @@ RSpec.describe DiscordMessages::Creator do
     end
 
     context 'when message exists' do
-      let(:message_id) { create(:message).id }
+      let(:message_uuid) { create(:message).uuid }
 
       it 'creates a discord message' do
         expect { creator.call }.to change(DiscordMessage, :count).by(1)
@@ -26,12 +26,12 @@ RSpec.describe DiscordMessages::Creator do
 
       it 'adds the discord message to the message' do
         creator.call
-        expect(Message.find(message_id).external_message).to eq(creator.discord_message)
+        expect(Message.find_by!(uuid: message_uuid).external_message).to eq(creator.discord_message)
       end
     end
 
     context 'when message does not exist' do
-      let(:message_id) { 0 }
+      let(:message_uuid) { 0 }
 
       it 'raises an error' do
         expect { creator.call }.to raise_error(ActiveRecord::RecordNotFound)
@@ -39,7 +39,7 @@ RSpec.describe DiscordMessages::Creator do
     end
 
     context 'when discord message creation fails' do
-      let(:message_id) { create(:message).id }
+      let(:message_uuid) { create(:message).uuid }
       let(:params) { { 'id' => '456' } } # missing 'channel_id' param
 
       it 'raises a Messages::CreationFailed error' do


### PR DESCRIPTION
# Description

## Motivation

<!--- Why is this change required? -->
<!--- What problem does it solve? -->

As a security layer, messages will by identify by a `uuid` instead of `id`, because `id` is progressive and can suggest a way to scrap for messages

## Solution

<!--- Write a clear description of your proposed changes. If possible, include supporting resources such as images or links. -->

implementing the uuid7 gem in the solution, we update routes to require `uuid` as param for `#show` actions; and for the discord integration

## Deploy TODOs

<!--- Is there anything exceptional that needs to be done to deploy these changes? -->
<!-- Any environment variables that need to be set or modified? List them here with their corresponding value for each environment -->
<!-- Any script that needs to be run? -->

## Checklist

- [x] I added/updated unit tests for these changes
- [x] I tested manually these changes
- [x] I updated the issue tracker and linked my PR to my ticket.

## Steps to reproduce

<!--- Please describe in detail how you tested your changes. -->
<!-- Add screenshots that support your manual tests  -->

### WEB
- create a message in `http://localhost:3000/` and as response you should get the message url with the `:uuid`
  ![image](https://github.com/user-attachments/assets/ef4d2e7c-c621-46dd-ad67-8be8f218c00a)
  ![image](https://github.com/user-attachments/assets/0d2b7f5e-2888-4885-b24d-08b81b1188f2)

- go to the message url, you should see the message
  ![image](https://github.com/user-attachments/assets/441c328b-3f69-4711-8326-42e1aea8390b)

### API
- request to `POST /api/messages` the response should avoid `:id` and include `:uuid`
  <img width="610" alt="image" src="https://github.com/user-attachments/assets/5f31ecd1-de66-46b6-b042-9ceaba60a1c0" />
  
 - request to `GET /api/message/:uuid` the response shuold include the correct message
  <img width="564" alt="image" src="https://github.com/user-attachments/assets/9a6c055b-a9a6-42b2-a463-bc09c47ef5c0" />

### DISCORD
- with Bot with permissions, create a message with 2 visits limit
  <img width="654" alt="image" src="https://github.com/user-attachments/assets/d3be5300-8605-4581-b206-c7f7879763b5" />
  <img width="583" alt="image" src="https://github.com/user-attachments/assets/ba696a9c-d2a1-4b15-a68b-97e295fc2796" />

- you should reveal it 2 times, and the it should be showed the expired notice
  <img width="507" alt="image" src="https://github.com/user-attachments/assets/a076b48e-9b70-4b8e-b918-6730eb9f18be" />
  <img width="507" alt="image" src="https://github.com/user-attachments/assets/a340d282-2601-444e-a49e-b71a7427b4e1" />  
  <img width="535" alt="image" src="https://github.com/user-attachments/assets/c200d542-1200-4f63-9905-fcc71fe65669" />

- remove Bot permissions
- create a message
- it should share you the link to the message, with the uuid instead of the id
  <img width="875" alt="image" src="https://github.com/user-attachments/assets/4e9273a0-888c-4be6-8b90-556651a32d9b" />






