### PR TITLE
CU-868bumud3 Remove message content at expiration

### DIFF
--- a/app/listeners/messages/check_message_expiration_listener.rb
+++ b/app/listeners/messages/check_message_expiration_listener.rb
@@ -1,0 +1,11 @@
+module Messages
+  class CheckMessageExpirationListener
+    def privy_message_read(payload)
+      message = payload[:message]
+      interface = message.interface
+      return if message.available? || !interface.internal?
+
+      ::Messages::Expirer.new(message).call
+    end
+  end
+end

--- a/app/models/interface.rb
+++ b/app/models/interface.rb
@@ -13,17 +13,17 @@ class Interface < ApplicationRecord
   scope :api, -> { find_by(source: :api) }
   scope :web, -> { find_by(source: :web) }
 
+  def internal?
+    return false unless source
+
+    INTERNAL_SOURCES.include?(source.to_sym)
+  end
+
   private
 
   def unique_source
     return unless self.class.where(source:).where.not(id:).exists?
 
     errors.add(:source, 'internal sources must be unique')
-  end
-
-  def internal?
-    return false unless source
-
-    INTERNAL_SOURCES.include?(source.to_sym)
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -22,7 +22,7 @@ class Message < ApplicationRecord
 
   has_rich_text :content, encrypted: true
 
-  validates :content, presence: true
+  validates :content, presence: true, unless: :expired
   validates :expiration_limit, numericality: { only_integer: true, greater_than: 0 }, presence: true
   validates :expiration_type, presence: true
   validates :expired, inclusion: { in: [true, false] }, allow_nil: false

--- a/app/services/messages/expirer.rb
+++ b/app/services/messages/expirer.rb
@@ -18,7 +18,8 @@ module Messages
     def expire_message!
       message.update!(
         expired: true,
-        expired_at: Time.zone.now
+        expired_at: Time.zone.now,
+        content: nil
       )
     end
   end

--- a/app/services/messages/reader.rb
+++ b/app/services/messages/reader.rb
@@ -9,9 +9,11 @@ module Messages
     def read_message
       check_availability!
       track_visit!
-      broadcast(:privy_message_read, { message: })
 
-      read_content
+      content = read_content
+      message.reload
+      broadcast(:privy_message_read, { message: })
+      content
     end
 
     private

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -4,4 +4,5 @@ Rails.application.reloader.to_prepare do
   Wisper.subscribe(Discord::Listeners::CreateExternalMessageListener.new)
   Wisper.subscribe(Discord::Listeners::SendExpiredNoticeListener.new)
   Wisper.subscribe(Discord::Listeners::HideOrExpireMessageListener.new)
+  Wisper.subscribe(Messages::CheckMessageExpirationListener.new)
 end

--- a/spec/listeners/messages/check_message_expiration_listener_spec.rb
+++ b/spec/listeners/messages/check_message_expiration_listener_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Messages::CheckMessageExpirationListener do
+  subject(:listener) { described_class.new }
+
+  describe '#privy_message_read' do
+    let(:interface) { create(:interface, source:) }
+    let(:message) do
+      Timecop.freeze(created_at) do
+        message = create(:message,
+                         interface:,
+                         expiration_type: :hour,
+                         expiration_limit: 1,
+                         expired: false)
+        message.content.update!(body: 'Test message')
+        message
+      end
+    end
+    let(:source) { :api }
+    let(:created_at) { 2.hours.ago }
+    let(:payload) { { message: } }
+
+    context 'when message is not available and interface is internal' do
+      it 'expires the message' do
+        expect { listener.privy_message_read(payload) }
+          .to change { message.reload.expired }.from(false).to(true)
+      end
+
+      it 'sets expired_at' do
+        expect { listener.privy_message_read(payload) }
+          .to change { message.reload.expired_at }.from(nil)
+      end
+
+      it 'blanks the message content' do
+        expect { listener.privy_message_read(payload) }
+          .to change { message.reload.content.body }.to(nil)
+      end
+    end
+
+    context 'when message is available' do
+      let(:created_at) { 30.minutes.ago }
+
+      it 'does not expire the message' do
+        expect { listener.privy_message_read(payload) }
+          .not_to(change { message.reload.expired })
+      end
+    end
+
+    context 'when interface is not internal' do
+      let(:source) { :discord_guild }
+
+      it 'does not expire the message' do
+        expect { listener.privy_message_read(payload) }
+          .not_to(change { message.reload.expired })
+      end
+    end
+  end
+end

--- a/spec/services/messages/expirer_spec.rb
+++ b/spec/services/messages/expirer_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Messages::Expirer do
       it 'adds expired_at timestamp' do
         expect { expirer.call }.to change { message.reload.expired_at }.from(nil)
       end
+
+      it 'clears content' do
+        expect { expirer.call }.to change { message.reload.content.body }.from(message.content.body).to(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

## Motivation

<!--- Why is this change required? -->
<!--- What problem does it solve? -->

We don't want to retain any message content

## Solution

<!--- Write a clear description of your proposed changes. If possible, include supporting resources such as images or links. -->

`Message` content has a `presence` constraint, but it is now enforced only when `expired` is set to false. When `expired` is true, the content can be nil, allowing the Expirer service to set it to nil

## Deploy TODOs

<!--- Is there anything exceptional that needs to be done to deploy these changes? -->
<!-- Any environment variables that need to be set or modified? List them here with their corresponding value for each environment -->
<!-- Any script that needs to be run? -->

## Checklist

- [x] I added/updated unit tests for these changes
- [x] I tested manually these changes
- [x] I updated the issue tracker and linked my PR to my ticket.

## Steps to reproduce

<!--- Please describe in detail how you tested your changes. -->
<!-- Add screenshots that support your manual tests  -->

We can try it with API and cosole:
- create a message
  <img width="724" alt="image" src="https://github.com/user-attachments/assets/29fa2e42-1d3c-4cde-a169-e229b458d2f8" />

- visit it 3 times to expire it, so at 4th visit:
  <img width="645" alt="image" src="https://github.com/user-attachments/assets/d30edea3-5982-4889-9563-64a7cd046225" />

 - at console run Message.find_by(uuid: <the uuid of the message>).content.body it should be nill
  <img width="476" alt="image" src="https://github.com/user-attachments/assets/8bcf62fc-702e-4408-8704-287f7aa11808" />


